### PR TITLE
feat: unit-aware chart selection with confidence scoring

### DIFF
--- a/app/services/chart_selector.py
+++ b/app/services/chart_selector.py
@@ -4,9 +4,32 @@ Generic chart selection engine for statistical datasets.
 Replaces the hardcoded archetype → chart mapping with a rules-based scoring system.
 The 4 existing archetypes (geo_time, demographic, time_residence, time_series) emerge
 naturally from the scores — they are no longer hardcoded inputs.
+
+Unit-type awareness: percentage data prefers area_stacked, index/rate data prefers line,
+currency/count data is neutral. Confidence scoring tells the frontend how certain we are.
 """
 import json
 
+
+# ---------------------------------------------------------------------------
+# Tie-breaking priority: when scores are equal, prefer more specific charts
+# Lower number = higher priority
+# ---------------------------------------------------------------------------
+TIEBREAK_PRIORITY = {
+    'choropleth': 0, 'population_pyramid': 1, 'line': 2,
+    'area_stacked': 3, 'grouped_bar': 4, 'small_multiples': 5,
+    'heatmap': 6, 'stacked_bar': 7, 'horizontal_bar': 8,
+    'bar_vertical': 9, 'bubble': 10, 'table': 11,
+}
+
+# Chart pairings that are complementary rather than competitive
+COMPLEMENTARY_PAIRS = {
+    frozenset({'choropleth', 'line'}): 'map shows spatial patterns, line shows time trends',
+    frozenset({'choropleth', 'horizontal_bar'}): 'map shows geography, bar ranks values',
+    frozenset({'population_pyramid', 'line'}): 'pyramid shows age structure, line shows change over time',
+    frozenset({'grouped_bar', 'heatmap'}): 'bar compares groups, heatmap shows all cross-sections',
+    frozenset({'line', 'small_multiples'}): 'line shows aggregate trend, small multiples show per-category trends',
+}
 
 # ---------------------------------------------------------------------------
 # 1. Signature builder — collapses all metadata into one dict
@@ -29,7 +52,6 @@ def build_signature(profile: dict, dimensions: list,
     vp = value_profile or {}
     tr = trend or {}
 
-    # Dimension counts
     indicator_dims = [
         {'name': d['dim_column_name'], 'count': d.get('option_count') or 0,
          'has_total': False, 'is_ordered': False}
@@ -52,6 +74,14 @@ def build_signature(profile: dict, dimensions: list,
     if coeff_var is not None and abs(coeff_var) > 100:
         coeff_var = 100.0
 
+    # Unit type enrichment
+    unit_types_raw = profile.get('unit_types', '[]') or '[]'
+    try:
+        unit_types = json.loads(unit_types_raw) if isinstance(unit_types_raw, str) else (unit_types_raw or [])
+    except (json.JSONDecodeError, TypeError):
+        unit_types = []
+    primary_unit = profile.get('primary_unit_type', 'count') or 'count'
+
     return {
         # Dimension presence
         'has_time': bool(profile.get('has_time')),
@@ -72,6 +102,9 @@ def build_signature(profile: dict, dimensions: list,
         'is_sparse': (cov.get('fill_rate') or 1.0) < 0.3,
         'distribution': vp.get('distribution_shape', 'unknown'),
         'coeff_variation': coeff_var,
+        # Unit type — drives chart affinity
+        'primary_unit_type': primary_unit,
+        'unit_types': unit_types,
         # Trend characteristics
         'trend_direction': tr.get('trend_direction', 'unknown'),
         'has_seasonality': bool(tr.get('has_seasonality')),
@@ -164,6 +197,7 @@ def _score(chart_type: str, sig: dict) -> float:
     cat_dims = sig['categorical_dims']
     has_residence = sig['has_residence']
     geo_levels = sig['geo_levels']
+    unit = sig.get('primary_unit_type', 'count')
 
     if chart_type == 'line':
         s = 0.5
@@ -173,27 +207,42 @@ def _score(chart_type: str, sig: dict) -> float:
         small_series = [d for d in cat_dims if d['count'] <= 6]
         if small_series: s += 0.1
         elif len(cat_dims) == 0 and has_residence: s += 0.1
-        if sig['has_seasonality']: s += 0.05
-        # No penalty for co-existing with choropleth — both are valid views
+        # Seasonality: line is THE chart for seasonal data
+        if sig['has_seasonality']: s += 0.15
+        if sig['time_granularity'] in ('monthly', 'quarterly'): s += 0.05
+        # Unit affinity: rates/indices are best shown as lines
+        if unit in ('rate', 'ratio', 'index'): s += 0.1
         return min(s, 1.0)
 
     if chart_type == 'area_stacked':
-        s = 0.3
+        s = 0.4  # raised base — area_stacked was chronically underscored
         series = [d for d in cat_dims if d['count'] <= 8]
-        if series: s += 0.2
+        if series: s += 0.15
         if 3 <= (series[0]['count'] if series else 0) <= 6: s += 0.1
         if tp >= 8: s += 0.1
-        return min(s, 1.0)
+        # Unit affinity: percentage data = parts-of-whole → area_stacked is ideal
+        if unit == 'percentage' and series:
+            s += 0.2
+            if 2 <= series[0]['count'] <= 6: s += 0.1  # perfect 100% stacking
+        # Sparse data makes stacked charts misleading (gaps look like zero)
+        if is_sparse: s -= 0.15
+        return min(max(s, 0.0), 1.0)
 
     if chart_type == 'bar_vertical':
-        # Bar is always a valid, clear alternative — higher base than before
-        s = 0.5
+        s = 0.45  # slightly lower base — was too greedy at 0.5
         if has_time and tp < 5: s += 0.15   # few time points → bar shines
         if not has_time: s += 0.1           # snapshot data
         cat_small = [d for d in cat_dims if d['count'] <= 15]
         if cat_small: s += 0.1
-        if has_geo and geo >= 5: s += 0.05  # ranking counties is natural as a bar
-        return min(s, 1.0)
+        if has_geo and geo >= 5: s += 0.05
+        # Penalty: bars hide trends in long time series — line is always better
+        if has_time and tp >= 10: s -= 0.15
+        elif has_time and tp >= 6: s -= 0.05
+        # Penalty: seasonal data needs continuous line, not discrete bars
+        if sig['has_seasonality']: s -= 0.10
+        # Unit penalty: index numbers as bar heights are misleading (base=100)
+        if unit == 'index': s -= 0.10
+        return min(max(s, 0.0), 1.0)
 
     if chart_type == 'grouped_bar':
         s = 0.3
@@ -205,42 +254,46 @@ def _score(chart_type: str, sig: dict) -> float:
         return min(s, 1.0)
 
     if chart_type == 'stacked_bar':
-        s = 0.35  # base bump — stacked bar is generally useful
+        s = 0.35
         small_series = [d for d in cat_dims if 2 <= d['count'] <= 4]
-        if small_series: s += 0.25  # sweet spot: 2-4 categories stack cleanly
-        elif has_gender or has_residence: s += 0.2  # M/F or Urban/Rural stack well
-        if has_time and tp < 5: s += 0.1   # few time points → bar over line
-        if has_time and tp >= 5: s += 0.05  # also fine for longer series
-        return min(s, 1.0)
+        if small_series: s += 0.25
+        elif has_gender or has_residence: s += 0.2
+        if has_time and tp < 5: s += 0.1
+        if has_time and tp >= 5: s += 0.05
+        # Unit affinity: percentage data stacks meaningfully
+        if unit == 'percentage' and small_series: s += 0.1
+        # Sparse data creates misleading gaps in stacks
+        if is_sparse: s -= 0.10
+        return min(max(s, 0.0), 1.0)
 
     if chart_type == 'horizontal_bar':
-        # Ranked bar — always clear for comparing many categories
         s = 0.5
         long_cats = [d for d in cat_dims if 10 <= d['count'] <= 50]
         if long_cats: s += 0.2
         if not has_time: s += 0.1
         elif has_time and tp == 1: s += 0.05
-        if has_geo and 10 <= geo <= 50: s += 0.1  # ranking counties by value
-        # Don't outrank choropleth for near-complete geo coverage
-        if has_geo and geo >= 30:
-            s = min(s, _score('choropleth', sig) - 0.05)
+        if has_geo and 10 <= geo <= 50: s += 0.1
+        # Unit affinity: currency/count are natural for comparison bars
+        if unit in ('currency', 'count'): s += 0.05
+        # Cap below choropleth for high geo coverage (explicit, no recursion)
+        if has_geo and geo >= 30: s = min(s, 0.80)
         return min(s, 1.0)
 
     if chart_type == 'choropleth':
-        s = 0.6   # spatial view is inherently valuable — higher base
-        if geo >= 30: s += 0.25  # near-complete county coverage = great map
+        s = 0.6
+        if geo >= 30: s += 0.25
         elif geo >= 20: s += 0.15
         elif geo >= 10: s += 0.05
         if 'county' in geo_levels: s += 0.05
-        if has_time: s += 0.05   # timeline animation bonus
-        if is_sparse: s -= 0.10  # sparse geo still makes a valid map (reduced penalty)
+        if has_time: s += 0.05
+        if is_sparse: s -= 0.10
         return min(max(s, 0.0), 1.0)
 
     if chart_type == 'population_pyramid':
         s = 0.0
         if has_age and has_gender:
             s = 0.7
-            if gender_count == 2: s += 0.2  # exactly M/F, no Total
+            if gender_count == 2: s += 0.2
             if sig['age_count'] >= 5: s += 0.1
         return min(s, 1.0)
 
@@ -251,7 +304,7 @@ def _score(chart_type: str, sig: dict) -> float:
         elif len(dims_10_30) == 1: s += 0.15
         if not is_sparse: s += 0.1
         if has_time and tp >= 5: s += 0.1
-        if cv > 0.5: s += 0.05  # interesting cross-tab variance
+        if cv > 0.5: s += 0.05
         return min(s, 1.0)
 
     if chart_type == 'small_multiples':
@@ -262,23 +315,25 @@ def _score(chart_type: str, sig: dict) -> float:
             s += 0.15
         if has_geo and 6 < geo <= 16: s += 0.2
         if tp >= 5: s += 0.1
-        return min(s, 1.0)
+        # Sparse data: many facets will be mostly empty
+        if is_sparse: s -= 0.10
+        return min(max(s, 0.0), 1.0)
 
     if chart_type == 'bubble':
-        s = 0.4  # solid alternative, not a primary default
-        if has_geo and geo >= 10: s += 0.15  # many geo units → readable bubble map
-        if has_geo and has_time: s += 0.1    # animate bubbles over time
+        s = 0.4
+        if has_geo and geo >= 10: s += 0.15
+        if has_geo and has_time: s += 0.1
         if len(cat_dims) >= 1 and has_time:
-            # scatter-bubble: x=time, y=value, size/color=category
             best_cat = min(cat_dims, key=lambda d: d['count'], default=None)
             if best_cat and best_cat['count'] <= 20: s += 0.1
-        # Never let bubble outrank choropleth for large geo — they're complementary
-        if has_geo and geo >= 20:
-            s = min(s, _score('choropleth', sig) - 0.05)
+        # Unit affinity: count/currency with large values → bubble size is meaningful
+        if unit in ('count', 'currency'): s += 0.05
+        # Cap below choropleth for high geo coverage (explicit, no recursion)
+        if has_geo and geo >= 20: s = min(s, 0.80)
         return min(max(s, 0.0), 1.0)
 
     if chart_type == 'table':
-        return 0.2  # always available but low priority
+        return 0.2
 
     return 0.0
 
@@ -295,11 +350,11 @@ CHART_TYPES = [
 
 
 def select_charts(sig: dict, top_n: int = 8) -> list[dict]:
-    """Return ranked list of applicable chart types with scores.
+    """Return ranked list of applicable chart types with scores and confidence.
 
     Returns:
-        List of dicts: [{chart_type, score, eligible}], sorted by score DESC.
-        First item = recommended primary chart.
+        List of dicts sorted by score DESC. First item = recommended primary.
+        Each entry: {chart_type, score, confidence, complementary_to?}
     """
     results = []
     for ct in CHART_TYPES:
@@ -307,17 +362,50 @@ def select_charts(sig: dict, top_n: int = 8) -> list[dict]:
             score = _score(ct, sig)
             results.append({'chart_type': ct, 'score': round(score, 3)})
 
-    results.sort(key=lambda x: -x['score'])
-    return results[:top_n]
+    # Deterministic tie-breaking: prefer more specific/informative charts
+    results.sort(key=lambda x: (-x['score'], TIEBREAK_PRIORITY.get(x['chart_type'], 99)))
+    results = results[:top_n]
+
+    # Confidence: how sure are we about the primary recommendation?
+    if len(results) >= 2:
+        gap = results[0]['score'] - results[1]['score']
+        confidence = 'high' if gap > 0.15 else 'medium' if gap > 0.05 else 'low'
+    elif len(results) == 1:
+        confidence = 'high'
+    else:
+        confidence = 'low'
+
+    for entry in results:
+        entry['confidence'] = confidence
+
+    # Mark complementary pairs among top results
+    top_types = {r['chart_type'] for r in results[:4]}
+    for entry in results:
+        for pair, reason in COMPLEMENTARY_PAIRS.items():
+            if entry['chart_type'] in pair:
+                partner = (pair - {entry['chart_type']})
+                if partner & top_types:
+                    entry['complementary_to'] = list(partner & top_types)[0]
+                    entry['complementary_reason'] = reason
+                    break
+
+    return results
 
 
-def assign_roles(chart_type: str, dimensions: list) -> dict:
+def assign_roles(chart_type: str, dimensions: list, sig: dict = None) -> dict:
     """Map dimension columns to visual roles for a given chart type.
 
-    Returns dict with keys: x_axis, series, facet, timeline, filter (list)
+    Args:
+        chart_type: The selected chart type
+        dimensions: List of dimension dicts
+        sig: Optional signature dict — enables context-aware assignment
+
+    Returns dict with keys: x_axis, series, facet, timeline, filter (list),
+    filter_hints (dict), defaults (dict)
     """
     roles = {'x_axis': None, 'series': None, 'facet': None,
-             'timeline': None, 'filter': []}
+             'timeline': None, 'filter': [], 'filter_hints': {},
+             'defaults': {}}
 
     by_type = {}
     for d in dimensions:
@@ -348,13 +436,18 @@ def assign_roles(chart_type: str, dimensions: list) -> dict:
 
     if chart_type == 'line':
         assign('x_axis', time_d)
-        # Best series: gender/residence > small indicator > age
+        # Best series: gender/residence > small indicator (2-6 sweet spot) > age
         if gender_d: assign('series', gender_d)
         elif residence_d: assign('series', residence_d)
         elif indicators:
-            best = min(indicators, key=lambda d: d.get('option_count') or 99)
-            if (best.get('option_count') or 0) <= 15:
+            # Prefer indicators in the 2-6 range (readable line count)
+            sweet = [d for d in indicators if 2 <= (d.get('option_count') or 0) <= 6]
+            small = [d for d in indicators if (d.get('option_count') or 0) <= 15]
+            best = min(sweet or small or [], key=lambda d: d.get('option_count') or 99, default=None)
+            if best:
                 assign('series', best)
+        if not roles['series'] and age_d and (age_d.get('option_count') or 0) <= 8:
+            assign('series', age_d)
         # Facet: another indicator with 6-25 options
         for d in indicators:
             if col(d) not in assigned and 6 < (d.get('option_count') or 0) <= 25:
@@ -363,7 +456,13 @@ def assign_roles(chart_type: str, dimensions: list) -> dict:
 
     elif chart_type in ('area_stacked', 'stacked_bar'):
         assign('x_axis', time_d)
-        if indicators:
+        # For stacking, prefer small categorical dims (parts-of-whole)
+        stackable = [d for d in indicators if 2 <= (d.get('option_count') or 0) <= 6]
+        if stackable:
+            assign('series', stackable[0])
+        elif has_gender_or_residence := (gender_d or residence_d):
+            assign('series', has_gender_or_residence)
+        elif indicators:
             assign('series', indicators[0])
 
     elif chart_type == 'bar_vertical':
@@ -398,7 +497,6 @@ def assign_roles(chart_type: str, dimensions: list) -> dict:
 
     elif chart_type == 'small_multiples':
         assign('x_axis', time_d)
-        # Facet: dim with 6-25 options
         for d in indicators:
             if 6 < (d.get('option_count') or 0) <= 25:
                 assign('facet', d)
@@ -407,7 +505,6 @@ def assign_roles(chart_type: str, dimensions: list) -> dict:
             assign('facet', geo_d)
 
     elif chart_type == 'horizontal_bar':
-        # Highest cardinality indicator or geo on the axis
         candidates = indicators + ([geo_d] if geo_d else [])
         if candidates:
             best = max(candidates, key=lambda d: d.get('option_count') or 0)
@@ -415,25 +512,35 @@ def assign_roles(chart_type: str, dimensions: list) -> dict:
         assign('timeline', time_d)
 
     elif chart_type == 'bubble':
-        # Bubble map: geo units as circles sized by value
-        # Scatter-bubble: x=time, y=value (implicit), color/size=category
         if geo_d:
-            assign('x_axis', geo_d)   # position on map
+            assign('x_axis', geo_d)
             assign('timeline', time_d)
             if indicators:
-                assign('series', indicators[0])  # color dimension
+                assign('series', indicators[0])
         else:
             assign('x_axis', time_d)
             if indicators:
-                assign('series', indicators[0])  # bubble color
+                assign('series', indicators[0])
             if len(indicators) > 1:
-                assign('facet', indicators[1])   # bubble size proxy
+                assign('facet', indicators[1])
 
-    # Everything not assigned → filter
-    all_dims = dimensions
-    roles['filter'] = [
-        col(d) for d in all_dims
-        if col(d) not in assigned and d.get('dim_type') != 'unit'
-    ]
+    # Everything not assigned → filter, with type hints
+    for d in dimensions:
+        c = col(d)
+        if c not in assigned and d.get('dim_type') != 'unit':
+            roles['filter'].append(c)
+            opt_count = d.get('option_count') or 0
+            if opt_count > 25:
+                roles['filter_hints'][c] = 'single_select'
+            elif opt_count > 6:
+                roles['filter_hints'][c] = 'multi_select'
+            else:
+                roles['filter_hints'][c] = 'pill_group'
+
+    # Recommended default filter state
+    if chart_type in ('choropleth', 'horizontal_bar', 'heatmap'):
+        roles['defaults']['time'] = 'latest'
+    if chart_type != 'population_pyramid':
+        roles['defaults']['exclude_total'] = True
 
     return roles

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -92,6 +92,27 @@ Future tasks and intentions for the TEMPO INS data explorer.
   rows (users expect individual records there). Add a `aggregate=true` parameter
   to the data endpoint.
 
+## Chart Selection — Future Improvements
+
+- [ ] **Treemap chart type** — For hierarchical categorical data (CAEN economic sectors),
+  treemap would show proportions better than horizontal bar. Requires frontend implementation.
+
+- [ ] **Sparkline/KPI view** — Datasets with 1 dimension (pure time series, no categories)
+  are perfect for a large KPI number + sparkline, not a full chart.
+
+- [ ] **Ratio/change chart mode** — Year-over-year change, growth rates, indexed values.
+  The trend data already detects these patterns; expose as an alternative view.
+
+- [ ] **Radar chart** — For comparing a small number of categories across multiple
+  metrics (e.g., county profiles across health/education/economy indicators).
+
+- [ ] **Unify `generate_view_profiles.py` with `chart_selector.py`** — Both contain
+  independent chart selection logic. The view profile generator has its own snapshot chart
+  rules that partially overlap. Long-term, view profiles should call `select_charts()`.
+
+- [ ] **Delete `app/services/chart_config.py`** — Dead code, no imports found. Kept for
+  reference during the transition period but should be removed.
+
 ## Data Quality
 
 - [ ] **Remove Total/aggregate rows from parquet files** — Rows like "Total", "Ambele sexe",

--- a/docs/activity-history.md
+++ b/docs/activity-history.md
@@ -1,5 +1,39 @@
 # Activity History
 
+## 2026-04-03 — Chart Selection Engine v2
+
+Comprehensive overhaul of `app/services/chart_selector.py` scoring engine.
+
+**Unit-type awareness:**
+- Signature now includes `primary_unit_type` and `unit_types` from matrix_profiles
+- Percentage data strongly prefers `area_stacked` (parts-of-whole visualization)
+- Index/rate data boosts `line` chart (continuous trends are meaningful)
+- Currency/count data gives small bonus to comparison bars and bubble charts
+- Index data penalizes `bar_vertical` (bar heights misleading for base-100 values)
+
+**Scoring rebalancing:**
+- `bar_vertical` base lowered from 0.5 to 0.45, penalized for long time series (>=10 pts: -0.15)
+- `area_stacked` base raised from 0.3 to 0.4, big boost for percentage+small-series data
+- Seasonal data: line gets +0.15 (was +0.05), bar_vertical gets -0.10
+- Sparse data penalties added to area_stacked (-0.15), stacked_bar (-0.10), small_multiples (-0.10)
+
+**Confidence scoring:**
+- Each recommendation now includes `confidence` (high/medium/low) based on score gap to runner-up
+- Complementary chart pairs annotated (e.g., choropleth ↔ line, pyramid ↔ line)
+
+**Deterministic tie-breaking:**
+- When scores tie, specific/informative charts win (choropleth > line > bar_vertical > table)
+
+**Smarter role assignment:**
+- `assign_roles()` now returns `filter_hints` (single_select/multi_select/pill_group per dim)
+- `defaults` dict with recommended initial filter state (e.g., time='latest', exclude_total=True)
+- Line series selection prefers 2-6 option dims over raw minimum cardinality
+- Stacked charts prefer stackable (2-6 option) dims for series role
+
+**Eliminated recursive scoring bug** — horizontal_bar and bubble no longer call `_score('choropleth', ...)` to cap themselves; use explicit score ceilings instead.
+
+**Synced** explorer/services/chart_selector.py. Updated test_chart_selector.py with unit-type distribution and confidence reporting.
+
 ## 2026-03-24 — SDMX-Native Data Format (Phases 0-4)
 
 Transformed the entire data layer from opaque integer IDs to SDMX-compatible, human-readable format.

--- a/explorer/services/chart_selector.py
+++ b/explorer/services/chart_selector.py
@@ -1,18 +1,53 @@
 """
 Generic chart selection engine for statistical datasets.
-Copied from app/services/chart_selector.py — kept as-is.
+
+Replaces the hardcoded archetype → chart mapping with a rules-based scoring system.
+The 4 existing archetypes (geo_time, demographic, time_residence, time_series) emerge
+naturally from the scores — they are no longer hardcoded inputs.
+
+Unit-type awareness: percentage data prefers area_stacked, index/rate data prefers line,
+currency/count data is neutral. Confidence scoring tells the frontend how certain we are.
 """
 import json
 
 
 # ---------------------------------------------------------------------------
-# 1. Signature builder
+# Tie-breaking priority: when scores are equal, prefer more specific charts
+# Lower number = higher priority
+# ---------------------------------------------------------------------------
+TIEBREAK_PRIORITY = {
+    'choropleth': 0, 'population_pyramid': 1, 'line': 2,
+    'area_stacked': 3, 'grouped_bar': 4, 'small_multiples': 5,
+    'heatmap': 6, 'stacked_bar': 7, 'horizontal_bar': 8,
+    'bar_vertical': 9, 'bubble': 10, 'table': 11,
+}
+
+# Chart pairings that are complementary rather than competitive
+COMPLEMENTARY_PAIRS = {
+    frozenset({'choropleth', 'line'}): 'map shows spatial patterns, line shows time trends',
+    frozenset({'choropleth', 'horizontal_bar'}): 'map shows geography, bar ranks values',
+    frozenset({'population_pyramid', 'line'}): 'pyramid shows age structure, line shows change over time',
+    frozenset({'grouped_bar', 'heatmap'}): 'bar compares groups, heatmap shows all cross-sections',
+    frozenset({'line', 'small_multiples'}): 'line shows aggregate trend, small multiples show per-category trends',
+}
+
+# ---------------------------------------------------------------------------
+# 1. Signature builder — collapses all metadata into one dict
 # ---------------------------------------------------------------------------
 
 def build_signature(profile: dict, dimensions: list,
                     coverage: dict | None = None,
                     value_profile: dict | None = None,
                     trend: dict | None = None) -> dict:
+    """Build a dataset signature from all available metadata.
+
+    Args:
+        profile:       Row from matrix_profiles
+        dimensions:    List of dim dicts with dim_type, dim_column_name, option_count
+        coverage:      Row from dataset_coverage (optional)
+        value_profile: Row from dataset_value_profiles (optional)
+        trend:         Row from dataset_trends (optional)
+    """
     cov = coverage or {}
     vp = value_profile or {}
     tr = trend or {}
@@ -35,10 +70,20 @@ def build_signature(profile: dict, dimensions: list,
         time_points = profile['time_year_max'] - profile['time_year_min'] + 1
 
     coeff_var = vp.get('coeff_variation')
+    # cap extreme values from near-zero means
     if coeff_var is not None and abs(coeff_var) > 100:
         coeff_var = 100.0
 
+    # Unit type enrichment
+    unit_types_raw = profile.get('unit_types', '[]') or '[]'
+    try:
+        unit_types = json.loads(unit_types_raw) if isinstance(unit_types_raw, str) else (unit_types_raw or [])
+    except (json.JSONDecodeError, TypeError):
+        unit_types = []
+    primary_unit = profile.get('primary_unit_type', 'count') or 'count'
+
     return {
+        # Dimension presence
         'has_time': bool(profile.get('has_time')),
         'time_points': int(time_points),
         'time_granularity': cov.get('time_granularity') or profile.get('time_granularity'),
@@ -52,12 +97,18 @@ def build_signature(profile: dict, dimensions: list,
         'has_residence': bool(profile.get('has_residence')),
         'categorical_dims': indicator_dims,
         'total_dims': int(profile.get('dim_count') or len(dimensions)),
+        # Value characteristics
         'has_negatives': (vp.get('negative_pct') or 0) > 0,
         'is_sparse': (cov.get('fill_rate') or 1.0) < 0.3,
         'distribution': vp.get('distribution_shape', 'unknown'),
         'coeff_variation': coeff_var,
+        # Unit type — drives chart affinity
+        'primary_unit_type': primary_unit,
+        'unit_types': unit_types,
+        # Trend characteristics
         'trend_direction': tr.get('trend_direction', 'unknown'),
         'has_seasonality': bool(tr.get('has_seasonality')),
+        # Original archetype for comparison
         '_archetype': profile.get('archetype', 'time_series'),
     }
 
@@ -70,7 +121,7 @@ def _dim_count(dimensions: list, dim_type: str) -> int:
 
 
 # ---------------------------------------------------------------------------
-# 2. Eligibility rules
+# 2. Eligibility rules (hard requirements)
 # ---------------------------------------------------------------------------
 
 def _eligible(chart_type: str, sig: dict) -> bool:
@@ -85,11 +136,14 @@ def _eligible(chart_type: str, sig: dict) -> bool:
     cat_dims = sig['categorical_dims']
     has_neg = sig['has_negatives']
     is_sparse = sig['is_sparse']
+    cv = sig['coeff_variation'] or 0
     has_residence = sig['has_residence']
 
     any_cat_gte5 = any(d['count'] >= 5 for d in cat_dims)
     any_cat_lte20 = any(d['count'] <= 20 for d in cat_dims)
     any_cat_facetable = any(6 < d['count'] <= 25 for d in cat_dims)
+    # Non-unit, non-time dims for stacked bar threshold
+    non_structural_dims = total_dims - (1 if has_time else 0) - 1  # subtract unit dim estimate
 
     if chart_type == 'line':
         return has_time and tp >= 3
@@ -100,6 +154,7 @@ def _eligible(chart_type: str, sig: dict) -> bool:
     if chart_type == 'grouped_bar':
         return total_dims >= 2 and (any_cat_lte20 or has_gender or has_age or has_residence)
     if chart_type == 'stacked_bar':
+        # Useful when simple structure (few dims) AND a categorical series with ≤ 4 options
         has_small_series = (
             any(d['count'] <= 4 for d in cat_dims)
             or has_gender or has_residence
@@ -116,6 +171,7 @@ def _eligible(chart_type: str, sig: dict) -> bool:
     if chart_type == 'small_multiples':
         return has_time and (any_cat_facetable or (has_geo and 6 < geo <= 25))
     if chart_type == 'bubble':
+        # Bubble map (geo units as circles) or scatter-bubble over time/categories
         return (has_geo and geo >= 5) or (has_time and len(cat_dims) >= 1 and tp >= 3)
     if chart_type == 'table':
         return True
@@ -123,7 +179,7 @@ def _eligible(chart_type: str, sig: dict) -> bool:
 
 
 # ---------------------------------------------------------------------------
-# 3. Relevance scoring
+# 3. Relevance scoring (soft preferences)
 # ---------------------------------------------------------------------------
 
 def _score(chart_type: str, sig: dict) -> float:
@@ -141,6 +197,7 @@ def _score(chart_type: str, sig: dict) -> float:
     cat_dims = sig['categorical_dims']
     has_residence = sig['has_residence']
     geo_levels = sig['geo_levels']
+    unit = sig.get('primary_unit_type', 'count')
 
     if chart_type == 'line':
         s = 0.5
@@ -150,29 +207,46 @@ def _score(chart_type: str, sig: dict) -> float:
         small_series = [d for d in cat_dims if d['count'] <= 6]
         if small_series: s += 0.1
         elif len(cat_dims) == 0 and has_residence: s += 0.1
-        if sig['has_seasonality']: s += 0.05
+        # Seasonality: line is THE chart for seasonal data
+        if sig['has_seasonality']: s += 0.15
+        if sig['time_granularity'] in ('monthly', 'quarterly'): s += 0.05
+        # Unit affinity: rates/indices are best shown as lines
+        if unit in ('rate', 'ratio', 'index'): s += 0.1
         return min(s, 1.0)
 
     if chart_type == 'area_stacked':
-        s = 0.3
+        s = 0.4  # raised base — area_stacked was chronically underscored
         series = [d for d in cat_dims if d['count'] <= 8]
-        if series: s += 0.2
+        if series: s += 0.15
         if 3 <= (series[0]['count'] if series else 0) <= 6: s += 0.1
         if tp >= 8: s += 0.1
-        return min(s, 1.0)
+        # Unit affinity: percentage data = parts-of-whole → area_stacked is ideal
+        if unit == 'percentage' and series:
+            s += 0.2
+            if 2 <= series[0]['count'] <= 6: s += 0.1  # perfect 100% stacking
+        # Sparse data makes stacked charts misleading (gaps look like zero)
+        if is_sparse: s -= 0.15
+        return min(max(s, 0.0), 1.0)
 
     if chart_type == 'bar_vertical':
-        s = 0.5
-        if has_time and tp < 5: s += 0.15
-        if not has_time: s += 0.1
+        s = 0.45  # slightly lower base — was too greedy at 0.5
+        if has_time and tp < 5: s += 0.15   # few time points → bar shines
+        if not has_time: s += 0.1           # snapshot data
         cat_small = [d for d in cat_dims if d['count'] <= 15]
         if cat_small: s += 0.1
         if has_geo and geo >= 5: s += 0.05
-        return min(s, 1.0)
+        # Penalty: bars hide trends in long time series — line is always better
+        if has_time and tp >= 10: s -= 0.15
+        elif has_time and tp >= 6: s -= 0.05
+        # Penalty: seasonal data needs continuous line, not discrete bars
+        if sig['has_seasonality']: s -= 0.10
+        # Unit penalty: index numbers as bar heights are misleading (base=100)
+        if unit == 'index': s -= 0.10
+        return min(max(s, 0.0), 1.0)
 
     if chart_type == 'grouped_bar':
         s = 0.3
-        if has_age and has_gender: s += 0.45
+        if has_age and has_gender: s += 0.45  # demographic sweet spot
         elif has_gender: s += 0.2
         elif has_age: s += 0.15
         elif has_residence: s += 0.1
@@ -186,7 +260,11 @@ def _score(chart_type: str, sig: dict) -> float:
         elif has_gender or has_residence: s += 0.2
         if has_time and tp < 5: s += 0.1
         if has_time and tp >= 5: s += 0.05
-        return min(s, 1.0)
+        # Unit affinity: percentage data stacks meaningfully
+        if unit == 'percentage' and small_series: s += 0.1
+        # Sparse data creates misleading gaps in stacks
+        if is_sparse: s -= 0.10
+        return min(max(s, 0.0), 1.0)
 
     if chart_type == 'horizontal_bar':
         s = 0.5
@@ -195,8 +273,10 @@ def _score(chart_type: str, sig: dict) -> float:
         if not has_time: s += 0.1
         elif has_time and tp == 1: s += 0.05
         if has_geo and 10 <= geo <= 50: s += 0.1
-        if has_geo and geo >= 30:
-            s = min(s, _score('choropleth', sig) - 0.05)
+        # Unit affinity: currency/count are natural for comparison bars
+        if unit in ('currency', 'count'): s += 0.05
+        # Cap below choropleth for high geo coverage (explicit, no recursion)
+        if has_geo and geo >= 30: s = min(s, 0.80)
         return min(s, 1.0)
 
     if chart_type == 'choropleth':
@@ -235,7 +315,9 @@ def _score(chart_type: str, sig: dict) -> float:
             s += 0.15
         if has_geo and 6 < geo <= 16: s += 0.2
         if tp >= 5: s += 0.1
-        return min(s, 1.0)
+        # Sparse data: many facets will be mostly empty
+        if is_sparse: s -= 0.10
+        return min(max(s, 0.0), 1.0)
 
     if chart_type == 'bubble':
         s = 0.4
@@ -244,8 +326,10 @@ def _score(chart_type: str, sig: dict) -> float:
         if len(cat_dims) >= 1 and has_time:
             best_cat = min(cat_dims, key=lambda d: d['count'], default=None)
             if best_cat and best_cat['count'] <= 20: s += 0.1
-        if has_geo and geo >= 20:
-            s = min(s, _score('choropleth', sig) - 0.05)
+        # Unit affinity: count/currency with large values → bubble size is meaningful
+        if unit in ('count', 'currency'): s += 0.05
+        # Cap below choropleth for high geo coverage (explicit, no recursion)
+        if has_geo and geo >= 20: s = min(s, 0.80)
         return min(max(s, 0.0), 1.0)
 
     if chart_type == 'table':
@@ -266,18 +350,62 @@ CHART_TYPES = [
 
 
 def select_charts(sig: dict, top_n: int = 8) -> list[dict]:
+    """Return ranked list of applicable chart types with scores and confidence.
+
+    Returns:
+        List of dicts sorted by score DESC. First item = recommended primary.
+        Each entry: {chart_type, score, confidence, complementary_to?}
+    """
     results = []
     for ct in CHART_TYPES:
         if _eligible(ct, sig):
             score = _score(ct, sig)
             results.append({'chart_type': ct, 'score': round(score, 3)})
-    results.sort(key=lambda x: -x['score'])
-    return results[:top_n]
+
+    # Deterministic tie-breaking: prefer more specific/informative charts
+    results.sort(key=lambda x: (-x['score'], TIEBREAK_PRIORITY.get(x['chart_type'], 99)))
+    results = results[:top_n]
+
+    # Confidence: how sure are we about the primary recommendation?
+    if len(results) >= 2:
+        gap = results[0]['score'] - results[1]['score']
+        confidence = 'high' if gap > 0.15 else 'medium' if gap > 0.05 else 'low'
+    elif len(results) == 1:
+        confidence = 'high'
+    else:
+        confidence = 'low'
+
+    for entry in results:
+        entry['confidence'] = confidence
+
+    # Mark complementary pairs among top results
+    top_types = {r['chart_type'] for r in results[:4]}
+    for entry in results:
+        for pair, reason in COMPLEMENTARY_PAIRS.items():
+            if entry['chart_type'] in pair:
+                partner = (pair - {entry['chart_type']})
+                if partner & top_types:
+                    entry['complementary_to'] = list(partner & top_types)[0]
+                    entry['complementary_reason'] = reason
+                    break
+
+    return results
 
 
-def assign_roles(chart_type: str, dimensions: list) -> dict:
+def assign_roles(chart_type: str, dimensions: list, sig: dict = None) -> dict:
+    """Map dimension columns to visual roles for a given chart type.
+
+    Args:
+        chart_type: The selected chart type
+        dimensions: List of dimension dicts
+        sig: Optional signature dict — enables context-aware assignment
+
+    Returns dict with keys: x_axis, series, facet, timeline, filter (list),
+    filter_hints (dict), defaults (dict)
+    """
     roles = {'x_axis': None, 'series': None, 'facet': None,
-             'timeline': None, 'filter': []}
+             'timeline': None, 'filter': [], 'filter_hints': {},
+             'defaults': {}}
 
     by_type = {}
     for d in dimensions:
@@ -308,12 +436,19 @@ def assign_roles(chart_type: str, dimensions: list) -> dict:
 
     if chart_type == 'line':
         assign('x_axis', time_d)
+        # Best series: gender/residence > small indicator (2-6 sweet spot) > age
         if gender_d: assign('series', gender_d)
         elif residence_d: assign('series', residence_d)
         elif indicators:
-            best = min(indicators, key=lambda d: d.get('option_count') or 99)
-            if (best.get('option_count') or 0) <= 15:
+            # Prefer indicators in the 2-6 range (readable line count)
+            sweet = [d for d in indicators if 2 <= (d.get('option_count') or 0) <= 6]
+            small = [d for d in indicators if (d.get('option_count') or 0) <= 15]
+            best = min(sweet or small or [], key=lambda d: d.get('option_count') or 99, default=None)
+            if best:
                 assign('series', best)
+        if not roles['series'] and age_d and (age_d.get('option_count') or 0) <= 8:
+            assign('series', age_d)
+        # Facet: another indicator with 6-25 options
         for d in indicators:
             if col(d) not in assigned and 6 < (d.get('option_count') or 0) <= 25:
                 assign('facet', d)
@@ -321,7 +456,13 @@ def assign_roles(chart_type: str, dimensions: list) -> dict:
 
     elif chart_type in ('area_stacked', 'stacked_bar'):
         assign('x_axis', time_d)
-        if indicators:
+        # For stacking, prefer small categorical dims (parts-of-whole)
+        stackable = [d for d in indicators if 2 <= (d.get('option_count') or 0) <= 6]
+        if stackable:
+            assign('series', stackable[0])
+        elif has_gender_or_residence := (gender_d or residence_d):
+            assign('series', has_gender_or_residence)
+        elif indicators:
             assign('series', indicators[0])
 
     elif chart_type == 'bar_vertical':
@@ -383,9 +524,23 @@ def assign_roles(chart_type: str, dimensions: list) -> dict:
             if len(indicators) > 1:
                 assign('facet', indicators[1])
 
-    roles['filter'] = [
-        col(d) for d in dimensions
-        if col(d) not in assigned and d.get('dim_type') != 'unit'
-    ]
+    # Everything not assigned → filter, with type hints
+    for d in dimensions:
+        c = col(d)
+        if c not in assigned and d.get('dim_type') != 'unit':
+            roles['filter'].append(c)
+            opt_count = d.get('option_count') or 0
+            if opt_count > 25:
+                roles['filter_hints'][c] = 'single_select'
+            elif opt_count > 6:
+                roles['filter_hints'][c] = 'multi_select'
+            else:
+                roles['filter_hints'][c] = 'pill_group'
+
+    # Recommended default filter state
+    if chart_type in ('choropleth', 'horizontal_bar', 'heatmap'):
+        roles['defaults']['time'] = 'latest'
+    if chart_type != 'population_pyramid':
+        roles['defaults']['exclude_total'] = True
 
     return roles

--- a/test_chart_selector.py
+++ b/test_chart_selector.py
@@ -113,8 +113,11 @@ def fmt_sig(sig):
     if sig['has_residence']: parts.append("residence")
     for d in sig['categorical_dims']:
         parts.append(f"ind({d['count']})")
+    unit = sig.get('primary_unit_type', 'count')
+    if unit != 'count': parts.append(f"unit={unit}")
     if sig['has_negatives']: parts.append("neg!")
     if sig['is_sparse']: parts.append("sparse!")
+    if sig['has_seasonality']: parts.append("seasonal!")
     if sig['trend_direction'] == 'volatile': parts.append("volatile!")
     return " | ".join(parts)
 
@@ -128,15 +131,19 @@ def spot_check(mc, profiles, dims_by_matrix, coverages, value_profiles, trends):
     print(f"  Signature: {fmt_sig(sig)}")
     print(f"  Old primary: {result['old_primary']}")
     print(f"  New primary: {result['new_primary']}  {'✓ agrees' if result['agrees'] else '⚠ differs'}")
+    if result['new_ranked']:
+        conf = result['new_ranked'][0].get('confidence', '?')
+        print(f"  Confidence: {conf}")
     print(f"\n  Ranked chart options:")
     for r in result['new_ranked']:
         bar = '█' * int(r['score'] * 20)
-        print(f"    {r['chart_type']:20s}  {r['score']:.2f}  {bar}")
+        comp = f"  ↔ {r['complementary_to']}" if r.get('complementary_to') else ""
+        print(f"    {r['chart_type']:20s}  {r['score']:.2f}  {bar}{comp}")
     roles = assign_roles(result['new_primary'], dims_by_matrix.get(mc, []))
     print(f"\n  Role assignment ({result['new_primary']}):")
     for role, val in roles.items():
-        if val and val != []:
-            print(f"    {role:12s}: {val}")
+        if val and val != [] and val != {}:
+            print(f"    {role:14s}: {val}")
 
 
 def main():
@@ -230,6 +237,25 @@ def main():
         if mc in profiles:
             spot_check(mc, profiles, dims_by_matrix, coverages, value_profiles, trends)
 
+    # ---- Unit type distribution ----
+    print(f"\n{'='*60}")
+    print("  UNIT TYPE × PRIMARY CHART")
+    print(f"{'='*60}")
+    unit_dist = Counter(r['sig'].get('primary_unit_type', 'count') for r in results)
+    for ut, cnt in unit_dist.most_common():
+        primaries = Counter(r['new_primary'] for r in results if r['sig'].get('primary_unit_type') == ut)
+        top3 = ", ".join(f"{ct}({n})" for ct, n in primaries.most_common(3))
+        print(f"  {ut:14s}  {cnt:4d}  → {top3}")
+
+    # ---- Confidence distribution ----
+    conf_dist = Counter(
+        r['new_ranked'][0].get('confidence', '?') if r['new_ranked'] else '?'
+        for r in results
+    )
+    print(f"\n  Confidence distribution:")
+    for conf, cnt in conf_dist.most_common():
+        print(f"    {conf:8s}  {cnt:4d}  ({100*cnt/total:.1f}%)")
+
     # ---- Interesting findings ----
     print(f"\n{'='*60}")
     print("  INTERESTING: Datasets that gain new chart options")
@@ -237,9 +263,11 @@ def main():
     gained_heatmap = [r for r in results if any(x['chart_type'] == 'heatmap' for x in r['new_ranked'])]
     gained_pyramid = [r for r in results if r['new_primary'] == 'population_pyramid']
     gained_small = [r for r in results if r['new_primary'] == 'small_multiples']
+    gained_area = [r for r in results if r['new_primary'] == 'area_stacked']
     print(f"  Datasets eligible for heatmap: {len(gained_heatmap)}")
     print(f"  Datasets primary = population_pyramid: {len(gained_pyramid)}")
     print(f"  Datasets primary = small_multiples: {len(gained_small)}")
+    print(f"  Datasets primary = area_stacked: {len(gained_area)}")
 
     if gained_pyramid:
         print(f"\n  Sample population pyramid datasets:")
@@ -249,6 +277,11 @@ def main():
     if gained_small:
         print(f"\n  Sample small_multiples datasets:")
         for r in gained_small[:5]:
+            print(f"    {r['matrix_code']:10s}  {fmt_sig(r['sig'])}")
+
+    if gained_area:
+        print(f"\n  Sample area_stacked datasets (boosted by unit awareness):")
+        for r in gained_area[:5]:
             print(f"    {r['matrix_code']:10s}  {fmt_sig(r['sig'])}")
 
 


### PR DESCRIPTION
## Summary

- **Unit-type awareness**: Signature now carries `primary_unit_type` from the pipeline. Percentage data → `area_stacked` wins (parts-of-whole); index/rate → `line` boosted; currency/count get small bar/bubble affinity bonus
- **Scoring rebalanced**: `bar_vertical` base lowered (0.5→0.45), penalized for long time series (≥10 pts: -0.15); `area_stacked` base raised (0.3→0.4); seasonal data boosts `line` (+0.15, was +0.05) and penalizes `bar_vertical` (-0.10)
- **Sparse data penalties**: Stacked charts with gaps look like zero values — added -0.10 to -0.15 for `area_stacked`, `stacked_bar`, `small_multiples` when data is sparse
- **Confidence scoring**: Each ranked chart now carries `confidence: high|medium|low` based on score gap to runner-up; complementary chart pairs annotated (e.g., choropleth ↔ line)
- **Deterministic tie-breaking**: Explicit priority table (choropleth > pyramid > line > area_stacked > … > table) — no more arbitrary sort-order dependence
- **Recursive scoring eliminated**: `horizontal_bar` and `bubble` previously called `_score('choropleth', sig)` to cap themselves — replaced with explicit ceilings
- **Smarter role assignment**: `filter_hints` (single_select / multi_select / pill_group per dim), `defaults` dict (time=latest, exclude_total), better series selection for stacked/line charts
- **Explorer synced**: `explorer/services/chart_selector.py` updated to match
- **Test harness updated**: unit-type distribution, confidence reporting, area_stacked gain tracking

## Test plan

- [ ] Run `python test_chart_selector.py` — verify distribution shifts (more area_stacked for percentage data, line dominates long time series)
- [ ] Spot-check: `python test_chart_selector.py --spot POP105A SOM101B ACC101B`
- [ ] Start app `uvicorn app.main:app --reload --port 8080` and browse a few datasets — confirm chart recommendations make visual sense
- [ ] Verify population pyramid / demographic datasets unchanged (regression check)

https://claude.ai/code/session_01HTEpY8a34PsBpKbSJPyobZ